### PR TITLE
feat: 감정일기 및 미션 페이지 UI/UX 개선

### DIFF
--- a/HiDaddy/src/screens/diary/CustomCalendar.js
+++ b/HiDaddy/src/screens/diary/CustomCalendar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import colors from '../../constants/colors';
 import styled from 'styled-components/native';
+import dayjs from 'dayjs';
 
 import LeftArrow from '../../assets/imgs/icons/left_arrow.svg';
 import RightArrow from '../../assets/imgs/icons/right_arrow.svg';
@@ -113,6 +114,8 @@ const CustomCalendar = ({
           const dayOfWeek = new Date(date.dateString).getDay();
           const isSunday = dayOfWeek === 0;
           const isSaturday = dayOfWeek === 6;
+          const isSelected = date.dateString === currentDateStr;
+
           const textColor =
             state === 'disabled'
               ? '#d9e1e8'
@@ -134,14 +137,16 @@ const CustomCalendar = ({
                 }
               }}
             >
-              <HmmText style={{ color: textColor, textAlign: 'center' }}>
-                {date.day}
-              </HmmText>
-              {hasDiary && (
-                <HeartWrapper>
-                  <HeartYellow width={10} height={10} />
-                </HeartWrapper>
-              )}
+              <DayContainer isSelected={isSelected}>
+                {hasDiary && (
+                  <HeartWrapper>
+                    <HeartYellow width={24} height={24} />
+                  </HeartWrapper>
+                )}
+                <HmmText style={{ color: textColor, textAlign: 'center', zIndex: 1 }}>
+                  {date.day}
+                </HmmText>
+              </DayContainer>
             </DayTouchable>
           );
         }}
@@ -179,11 +184,21 @@ const ArrowButton = styled.TouchableOpacity``;
 
 const HeartWrapper = styled.View`
   position: absolute;
-  bottom: 18px;
+  z-index: 0;
 `;
 
 const DayTouchable = styled.TouchableOpacity`
   align-items: center;
   justify-content: center;
+  height: 40px;
+`;
+
+const DayContainer = styled.View`
+  width: 30px;
+  height: 30px;
+  border-radius: 15px;
+  align-items: center;
+  justify-content: center;
+  background-color: ${props => props.isSelected ? colors.primary : 'transparent'};
   position: relative;
 `;

--- a/HiDaddy/src/screens/diary/DiaryScreen.js
+++ b/HiDaddy/src/screens/diary/DiaryScreen.js
@@ -11,7 +11,7 @@ import CustomCalendar from './CustomCalendar.js';
 import Background from '../../components/Background';
 import { HmmBText, HmmText } from '../../components/CustomText';
 import { Dimensions, Image, ScrollView, TouchableOpacity } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 
 const { width } = Dimensions.get('window');
 
@@ -20,6 +20,7 @@ const DiaryScreen = () => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [diaryList, setDiaryList] = useState([]);
   const [selectedDiary, setSelectedDiary] = useState(null);
+  const [hasSelectedDate, setHasSelectedDate] = useState(false);
 
   const startDate = dayjs().startOf('month').format('YYYY-MM-DD');
   const endDate = dayjs().endOf('month').format('YYYY-MM-DD');
@@ -52,58 +53,90 @@ const DiaryScreen = () => {
       const response = await get(config.DIARY.DIARY(date));
       console.log('Res', response);
       setSelectedDiary(response);
+      return response;
     } catch (error) {
       console.error('개별 일기 가져오기 실패:', error);
+      return null;
     }
   };
 
   useEffect(() => {
-    fetchDiaryList();
+    const initializeDiary = async () => {
+      await fetchDiaryList();
+      // 오늘 날짜로 자동 선택
+      const today = dayjs().format('YYYY-MM-DD');
+      setHasSelectedDate(true);
+      await fetchDiaryByDate(today);
+    };
+
+    initializeDiary();
   }, []);
+
+  // 화면에 포커스될 때마다 일기 목록 새로고침
+  useFocusEffect(
+    React.useCallback(() => {
+      const refreshDiary = async () => {
+        await fetchDiaryList();
+        // 현재 선택된 날짜의 일기 다시 불러오기
+        if (hasSelectedDate) {
+          const currentDateStr = dayjs(currentDate).format('YYYY-MM-DD');
+          await fetchDiaryByDate(currentDateStr);
+        }
+      };
+
+      refreshDiary();
+    }, [currentDate, hasSelectedDate])
+  );
 
   return (
     <Wrapper>
       <Background />
-      <Content>
-        <DiaryMain>
-          <DiaryMainTitle>
-            <MainTitle>사랑이 가득차는 순간들</MainTitle>
-            <TouchableWrite
-              onPress={() =>
-                navigation.navigate('DiaryStackNavigator', {
-                  screen: 'DiaryWriteScreen',
-                })
-              }
-            >
-              <Write width={35} height={35} />
-            </TouchableWrite>
-          </DiaryMainTitle>
-          <DiarySubTitle>
-            <SubTitle>지금, 그 감정을 남겨보세요.</SubTitle>
-          </DiarySubTitle>
-        </DiaryMain>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ flexGrow: 1 }}
+      >
+        <Content>
+          <DiaryMain>
+            <DiaryMainTitle>
+              <MainTitle>사랑이 가득차는 순간들</MainTitle>
+              <TouchableWrite
+                onPress={async () => {
+                  const today = dayjs().format('YYYY-MM-DD');
+                  const todayDiary = await fetchDiaryByDate(today);
 
-        <CalendarWrapper>
-          <CustomCalendar
-            currentDate={currentDate}
-            setCurrentDate={date => {
-              setCurrentDate(date);
-              setSelectedDiary(null);
-              fetchDiaryByDate(dayjs(date).format('YYYY-MM-DD'));
-            }}
-            diaryDates={diaryList.map(item => item.date)}
-            onSelectDate={date => {
-              setSelectedDiary(null);
-              fetchDiaryByDate(dayjs(date).format('YYYY-MM-DD'));
-            }}
-          />
-        </CalendarWrapper>
+                  navigation.navigate('DiaryStackNavigator', {
+                    screen: 'DiaryWriteScreen',
+                    params: todayDiary?.content ? { diary: todayDiary } : { date: today },
+                  });
+                }}
+              >
+                <Write width={35} height={35} />
+              </TouchableWrite>
+            </DiaryMainTitle>
+            <DiarySubTitle>
+              <SubTitle>지금, 그 감정을 남겨보세요.</SubTitle>
+            </DiarySubTitle>
+          </DiaryMain>
 
-        <DiaryPost>
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={{ paddingBottom: 30 }}
-          >
+          <CalendarWrapper>
+            <CustomCalendar
+              currentDate={currentDate}
+              setCurrentDate={date => {
+                setCurrentDate(date);
+                setSelectedDiary(null);
+                setHasSelectedDate(true);
+                fetchDiaryByDate(dayjs(date).format('YYYY-MM-DD'));
+              }}
+              diaryDates={diaryList.map(item => item.date)}
+              onSelectDate={date => {
+                setSelectedDiary(null);
+                setHasSelectedDate(true);
+                fetchDiaryByDate(dayjs(date).format('YYYY-MM-DD'));
+              }}
+            />
+          </CalendarWrapper>
+
+          <DiaryPost>
             {selectedDiary && selectedDiary.content ? (
               <TouchableDiaryItem
                 onPress={() =>
@@ -114,16 +147,33 @@ const DiaryScreen = () => {
                 }
               >
                 {selectedDiary.imageUrl ? (
-                  <DiaryImage source={{ uri: selectedDiary.imageUrl }} />
+                  <DiaryImage
+                    source={{ uri: selectedDiary.imageUrl }}
+                    onLoad={(e) => {
+                      const { width: imgWidth, height: imgHeight } = e.nativeEvent.source;
+                      const aspectRatio = imgWidth / imgHeight;
+                      e.target.setNativeProps({
+                        style: {
+                          aspectRatio: aspectRatio
+                        }
+                      });
+                    }}
+                  />
                 ) : null}
                 <DiaryText>{selectedDiary.content}</DiaryText>
               </TouchableDiaryItem>
             ) : (
-              <EmptyText>일기를 확인할 날짜를 선택하세요.</EmptyText>
+              <EmptyText>
+                {hasSelectedDate
+                  ? dayjs(currentDate).format('YYYY-MM-DD') === dayjs().format('YYYY-MM-DD')
+                    ? '오늘 날짜에 작성된 일기가 없습니다.'
+                    : '선택한 날짜에 작성된 일기가 없습니다.'
+                  : '일기를 확인할 날짜를 선택하세요.'}
+              </EmptyText>
             )}
-          </ScrollView>
-        </DiaryPost>
-      </Content>
+          </DiaryPost>
+        </Content>
+      </ScrollView>
     </Wrapper>
   );
 };
@@ -134,9 +184,9 @@ const Wrapper = styled.View`
   flex: 1;
 `;
 const Content = styled.View`
-  flex: 1;
   margin-top: 30px;
   padding: ${width * 0.1}px;
+  padding-bottom: 30px;
 `;
 const DiaryMain = styled.View``;
 const DiaryMainTitle = styled.View`
@@ -160,7 +210,6 @@ const CalendarWrapper = styled.View`
   overflow: hidden;
 `;
 const DiaryPost = styled.View`
-  flex: 1;
   margin-top: ${width * 0.04}px;
 `;
 const TouchableDiaryItem = styled(TouchableOpacity)`
@@ -175,8 +224,8 @@ const DiaryText = styled(HmmText)`
 `;
 const DiaryImage = styled(Image)`
   width: 100%;
-  height: 150px;
   border-radius: 10px;
+  resize-mode: contain;
 `;
 const EmptyText = styled(HmmText)`
   font-size: ${width * 0.04}px;

--- a/HiDaddy/src/screens/diary/DiaryWriteScreen.js
+++ b/HiDaddy/src/screens/diary/DiaryWriteScreen.js
@@ -4,7 +4,6 @@ import colors from '../../constants/colors';
 import { post, del, put, get } from '../../services/api';
 import config from '../../constants/config';
 
-import Send from '../../assets/imgs/icons/send.svg';
 import Gallery from '../../assets/imgs/icons/addimg.svg';
 import { HmmBText, HmmText } from '../../components/CustomText';
 import { useNavigation, useRoute } from '@react-navigation/native';
@@ -24,7 +23,6 @@ const DiaryWriteScreen = () => {
 
   const [isEditing, setIsEditing] = useState(!diary);
   const [diaryText, setDiaryText] = useState(diary?.content || '');
-  const [messageText, setMessageText] = useState(diary?.message || '');
   const [imageUri, setImageUri] = useState(diary?.imageUrl || null);
   const [hasDiary, setHasDiary] = useState(!!diary);
   const [currentWeek, setCurrentWeek] = useState(null);
@@ -82,7 +80,6 @@ const DiaryWriteScreen = () => {
     try {
       const formData = new FormData();
       formData.append('content', diaryText);
-      formData.append('message', messageText);
       formData.append('date', diaryDate);
 
       if (imageUri) {
@@ -121,7 +118,6 @@ const DiaryWriteScreen = () => {
     try {
       const formData = new FormData();
       formData.append('content', diaryText);
-      formData.append('message', messageText);
 
       if (imageUri && imageUri !== diary?.imageUrl) {
         formData.append('image', {
@@ -139,7 +135,6 @@ const DiaryWriteScreen = () => {
       setIsEditing(false);
 
       setDiaryText(diaryText);
-      setMessageText(messageText);
       setImageUri(imageUri || diary?.imageUrl);
     } catch (error) {
       console.error('일기 수정 실패:', error);
@@ -147,22 +142,10 @@ const DiaryWriteScreen = () => {
     }
   };
 
-  const sendMessage = async () => {
-    try {
-      const url = `${config.MESSAGE.SEND_MESSAGE}?text=${encodeURIComponent(messageText)}`;
-      await post(url, {});
-      Alert.alert('완료', '메시지가 전송되었습니다.');
-    } catch (error) {
-      console.error('메시지 전송 실패:', error.response?.data || error.message);
-      Alert.alert('전송 실패', '메시지 전송 중 오류가 발생했습니다.');
-    }
-  };
-
   useEffect(() => {
     if (!diary) return;
 
     setDiaryText(diary.content || '');
-    setMessageText(diary.message || '');
     setImageUri(diary.imageUrl || null);
     setHasDiary(true);
     setIsEditing(false);
@@ -199,7 +182,7 @@ const DiaryWriteScreen = () => {
         }
       },
     });
-  }, [navigation, isEditing, hasDiary, diaryText, imageUri, messageText]);
+  }, [navigation, isEditing, hasDiary, diaryText, imageUri]);
 
   return (
     <Wrapper>
@@ -234,24 +217,6 @@ const DiaryWriteScreen = () => {
           </DiaryTopSection>
 
           <DiarySubContent>
-            <DiaryMessage>
-              <MessageTitle>아내에게 하고싶은 말 한마디</MessageTitle>
-              <MessageContent>
-                <MessageInput
-                  value={messageText}
-                  onChangeText={setMessageText}
-                  editable={isEditing}
-                  placeholder={'직접 말하지 못한걸 글로 표현해보는건 어떨까요?'}
-                  placeholderTextColor="#999"
-                  multiline
-                  textAlignVertical="top"
-                />
-                <TouchableOpacity onPress={sendMessage}>
-                  <Send width={30} height={30} />
-                </TouchableOpacity>
-              </MessageContent>
-            </DiaryMessage>
-
             <DiaryRecordImg>
               <TouchableOpacity onPress={handleSelectImage} disabled={!isEditing}>
                 <CommunityAddImg>
@@ -318,30 +283,7 @@ const DiarySubContent = styled.View`
   padding-top: ${width * 0.01}px;
 `;
 
-const DiaryMessage = styled.View`
-  margin-top: ${width * 0.05}px;
-`;
-
-const MessageTitle = styled(HmmBText)`
-  font-size: ${width * 0.04}px;
-`;
-
-const MessageContent = styled.View`
-  flex-direction: row;
-  align-items: center;
-  gap: ${width * 0.02}px;
-`;
-
-const MessageInput = styled.TextInput`
-  flex: 1;
-  font-family: 'HancomMalangMalang-Regular';
-  font-size: ${width * 0.038}px;
-  line-height: 23px;
-`;
-
 const DiaryRecordImg = styled.View`
-  border-top-width: 1px;
-  border-top-color: ${colors.gray100};
   margin-top: ${width * 0.04}px;
 `;
 

--- a/HiDaddy/src/screens/home/HomeScreen.js
+++ b/HiDaddy/src/screens/home/HomeScreen.js
@@ -123,7 +123,8 @@ const HomeScreen = () => {
         <DescriptionText>
           아빠가 기록한 감정 일기와,{'\n'}
           아내의 현재 임신 주차 정보를 기반으로{'\n'}
-          오늘 전하면 좋을 다정한 실천을 AI가 추천해드립니다.
+          오늘 전하면 좋을 다정한 실천을 AI가 추천해드립니다.{'\n'}
+          아내에게 간편하게 한 줄 메시지도 보낼 수 있어요.
         </DescriptionText>
 
         <Image
@@ -144,7 +145,7 @@ const HomeScreen = () => {
             })
           }
         >
-          <RowText>오늘의 마음 전하기</RowText>
+          <RowText>미션 & 메시지 보내기</RowText>
           <RightArrow width={24} height={24} />
         </TouchableRow>
       </Content>
@@ -154,6 +155,9 @@ const HomeScreen = () => {
           navigation.navigate('EtcStackNavigator', { screen: 'ChatBotScreen' })
         }
       >
+        <ChatbotTooltip>
+          <TooltipText>궁금한 게 있다면{'\n'}챗봇에게 물어보세요!</TooltipText>
+        </ChatbotTooltip>
         <ChatbotCircle>
           <Bot width={32} height={32} />
         </ChatbotCircle>
@@ -248,6 +252,27 @@ const ChatbotButton = styled.TouchableOpacity`
   position: absolute;
   bottom: ${width * 0.08}px;
   right: ${width * 0.06}px;
+  align-items: flex-end;
+`;
+
+const ChatbotTooltip = styled.View`
+  background-color: ${colors.white};
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1.5px solid ${colors.black};
+  margin-bottom: 8px;
+  elevation: 2;
+  shadow-color: #000;
+  shadow-offset: 0px 2px;
+  shadow-opacity: 0.1;
+  shadow-radius: 4px;
+`;
+
+const TooltipText = styled(HmmText)`
+  font-size: ${width * 0.032}px;
+  color: ${colors.black};
+  text-align: center;
+  line-height: 16px;
 `;
 
 const ChatbotCircle = styled.View`

--- a/HiDaddy/src/screens/home/mission/MissionScreen.js
+++ b/HiDaddy/src/screens/home/mission/MissionScreen.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components/native';
-import { Dimensions, Alert } from 'react-native';
+import { Dimensions, Alert, TouchableOpacity, ScrollView } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
 import colors from '../../../constants/colors';
@@ -8,6 +8,7 @@ import Background from '../../../components/Background';
 
 import RightArrow from '../../../assets/imgs/icons/right_arrow.svg';
 import HeartYellow from '../../../assets/imgs/icons/heart_yellow.svg';
+import Send from '../../../assets/imgs/icons/send.svg';
 import { HmmText, HmmBText } from '../../../components/CustomText';
 
 import { post, get } from '../../../services/api';
@@ -21,6 +22,7 @@ const MissionScreen = () => {
     const [currentMissionId, setCurrentMissionId] = useState(null);
     const [doneMissions, setDoneMissions] = useState([]);
     const [alreadyDone, setAlreadyDone] = useState(false);
+    const [messageText, setMessageText] = useState('');
 
     const fetchMission = async () => {
         try {
@@ -72,58 +74,114 @@ const MissionScreen = () => {
         navigation.navigate('MissionPerformScreen');
     };
 
+    const sendMessage = async () => {
+        if (!messageText.trim()) {
+            Alert.alert('알림', '메시지를 입력해주세요.');
+            return;
+        }
+
+        try {
+            const url = `${config.MESSAGE.SEND_MESSAGE}?text=${encodeURIComponent(messageText)}`;
+            await post(url, {});
+            Alert.alert('완료', '메시지가 전송되었습니다.');
+            setMessageText('');
+        } catch (error) {
+            // console.error('메시지 전송 실패:', error.response?.data || error.message);
+            Alert.alert(
+                '아내 전화번호 등록 필요',
+                '메시지를 보내려면 아내의 전화번호가 필요합니다.\n마이페이지 > 내 정보에서 등록해주세요.',
+                [
+                    { text: '취소', style: 'cancel' },
+                    {
+                        text: '설정하러 가기',
+                        onPress: () => {
+                            navigation.navigate('MypageStackNavigator', {
+                                screen: 'MyInfoScreen'
+                            });
+                        }
+                    }
+                ]
+            );
+        }
+    };
+
     return(
         <Wrapper>
             <Background />
-            <Content>
-                <Title>
-                    오늘까지 {'\n'}
-                    총 {doneMissions.length}개의 마음을 전했어요!
-                </Title>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ flexGrow: 1 }}
+            >
+                <Content>
+                    <Title>
+                        오늘까지 {'\n'}
+                        총 {doneMissions.length}개의 마음을 전했어요!
+                    </Title>
 
-                <MissionMain>
-                    <MissionMainTitle>
-                        <HeartYellow width={24} height={24}/>
-                        <SectionTitle>오늘의 마음 전하기</SectionTitle>
-                    </MissionMainTitle>
-                    <MissionMainList>
-                        <TouchableRow
-                            onPress={handleMissionPress}
-                        >
-                            <MissionText>{missionTitle}</MissionText>
-                            <RightArrow width={20} height={20}/>
-                        </TouchableRow>
-                    </MissionMainList>
-                </MissionMain>
+                    <MessageSection>
+                        <MessageSectionTitle>
+                            <HeartYellow width={24} height={24}/>
+                            <SectionTitle>아내에게 한 줄 메시지 보내기</SectionTitle>
+                        </MessageSectionTitle>
+                        <MessageInputContainer>
+                            <MessageInput
+                                value={messageText}
+                                onChangeText={setMessageText}
+                                placeholder="말로는 부끄러운 마음, 글로 전해보세요"
+                                placeholderTextColor={colors.gray200}
+                                multiline
+                                textAlignVertical="top"
+                            />
+                            <TouchableOpacity onPress={sendMessage}>
+                                <Send width={30} height={30} />
+                            </TouchableOpacity>
+                        </MessageInputContainer>
+                    </MessageSection>
 
-                <MissionDone>
-                    <MissionDoneTitle>
-                        <HeartYellow width={24} height={24}/>
-                        <SectionTitle>전달한 마음 목록</SectionTitle>
-                    </MissionDoneTitle>
-                    <MissionDoneList>
-                        {doneMissions.length === 0 ? (
-                            <DoneListText>수행한 미션이 없습니다.</DoneListText>
-                        ) : (
-                            doneMissions.map((mission) => (
-                                <TouchableRow
-                                    key={mission.id}
-                                    onPress={() =>
-                                        navigation.navigate('MissionDetailScreen', {
-                                            missionId: mission.missionId
-                                        })
-                                    }
-                                >
-                                    <DoneListRow>
-                                        <DoneListText>{mission.missionTitle}</DoneListText>
-                                        <RightArrow width={20} height={20}/>
-                                    </DoneListRow>
-                                </TouchableRow>
-                            ))
-                        )}
-                    </MissionDoneList>
-                </MissionDone>
-            </Content>
+                    <MissionMain>
+                        <MissionMainTitle>
+                            <HeartYellow width={24} height={24}/>
+                            <SectionTitle>AI 추천 미션 수행하기</SectionTitle>
+                        </MissionMainTitle>
+                        <MissionMainList>
+                            <TouchableRow
+                                onPress={handleMissionPress}
+                            >
+                                <MissionText>{missionTitle}</MissionText>
+                                <RightArrow width={20} height={20}/>
+                            </TouchableRow>
+                        </MissionMainList>
+                    </MissionMain>
+
+                    <MissionDone>
+                        <MissionDoneTitle>
+                            <HeartYellow width={24} height={24}/>
+                            <SectionTitle>완료한 미션 목록</SectionTitle>
+                        </MissionDoneTitle>
+                        <MissionDoneList>
+                            {doneMissions.length === 0 ? (
+                                <DoneListText>수행한 미션이 없습니다.</DoneListText>
+                            ) : (
+                                doneMissions.map((mission) => (
+                                    <TouchableRow
+                                        key={mission.id}
+                                        onPress={() =>
+                                            navigation.navigate('MissionDetailScreen', {
+                                                missionId: mission.missionId
+                                            })
+                                        }
+                                    >
+                                        <DoneListRow>
+                                            <DoneListText>{mission.missionTitle}</DoneListText>
+                                            <RightArrow width={20} height={20}/>
+                                        </DoneListRow>
+                                    </TouchableRow>
+                                ))
+                            )}
+                        </MissionDoneList>
+                    </MissionDone>
+                </Content>
+            </ScrollView>
         </Wrapper>
     );
 };
@@ -136,6 +194,7 @@ const Wrapper = styled.View`
 
 const Content = styled.View`
   padding: ${width * 0.07}px;
+  padding-bottom: 30px;
 `;
 
 const Title = styled(HmmBText)`
@@ -152,11 +211,14 @@ const MissionMain = styled.View`
 
 const MissionMainTitle = styled.View`
     flex-direction: row;
+    align-items: center;
+    gap: ${width * 0.02}px;
 `;
 
 const MissionMainList = styled.View`
     flex-direction: row;
     align-items: center;
+    margin-top: 10px;
 `;
 
 const TouchableRow = styled.TouchableOpacity`
@@ -170,12 +232,14 @@ const TouchableRow = styled.TouchableOpacity`
 const MissionDoneTitle = styled.View`
     flex-direction: row;
     margin-top: 30px;
+    align-items: center;
+    gap: ${width * 0.02}px;
 `;
 
 const SectionTitle = styled(HmmBText)`
     font-size: ${width * 0.05}px;
     color: ${colors.black};
-    margin-bottom: 10px;
+    line-height: ${width * 0.05}px;
 `;
 
 const MissionText = styled(HmmText)`
@@ -184,10 +248,39 @@ const MissionText = styled(HmmText)`
     margin-left: 8px;
 `;
 
+const MessageSection = styled.View`
+    margin-top: 30px;
+`;
+
+const MessageSectionTitle = styled.View`
+    flex-direction: row;
+    align-items: center;
+    gap: ${width * 0.02}px;
+`;
+
+const MessageInputContainer = styled.View`
+    flex-direction: row;
+    align-items: center;
+    gap: ${width * 0.02}px;
+    margin-top: 10px;
+    padding: 10px;
+    border-radius: 10px;
+    background-color: ${colors.gray50};
+`;
+
+const MessageInput = styled.TextInput`
+    flex: 1;
+    font-family: 'HancomMalangMalang-Regular';
+    font-size: ${width * 0.04}px;
+    color: ${colors.black};
+    min-height: 40px;
+    max-height: 100px;
+`;
+
 const MissionDone = styled.View`
     font-size: ${width * 0.05}px;
     color: ${colors.black};
-    margin-top: 20px;
+    margin-top: 30px;
     flex-direction: column;
 `;
 
@@ -195,6 +288,7 @@ const MissionDoneList = styled.View`
     font-size: ${width * 0.05}px;
     flex-direction: column;
     gap: 10px;
+    margin-top: 10px;
 `;
 
 const DoneListText = styled(HmmText)`

--- a/HiDaddy/src/screens/mypage/MypageScreen.js
+++ b/HiDaddy/src/screens/mypage/MypageScreen.js
@@ -90,7 +90,7 @@ const MypageScreen = ({ navigation: { navigate } }) => {
       <Background />
       <Content>
         <HeaderContainer>
-          <HeaderTitle>하트 교환소</HeaderTitle>
+          <HeaderTitle>마이페이지</HeaderTitle>
         </HeaderContainer>
         <MenuContainer>
           <MenuItem


### PR DESCRIPTION
## 감정일기 (Diary)
- 오늘 날짜 자동 선택 및 일기 로드
- 날짜별 메시지 구분 (오늘/다른 날짜)
- 캘린더 하트 아이콘을 날짜 뒤 배경으로 배치
- 날짜 선택 시 텍스트가 사라지는 문제 수정
- 이미지 원본 비율 유지하여 표시
- 화면 전체 스크롤 적용
- 작성/삭제 후 자동 새로고침 (useFocusEffect)
- 작성 버튼 클릭 시 오늘 일기 있으면 기존 일기 표시
- 메시지 전송 기능 제거 (미션 페이지로 이동)

## 미션 페이지 (Mission)
- "아내에게 한 줄 메시지 보내기" 기능 추가
- 섹션 순서 변경 (메시지 > AI 미션 > 히스토리)
- 섹션 제목 명확화 ("AI 추천 미션 수행하기", "완료한 미션 목록")
- 하트 아이콘과 텍스트 수평 정렬 개선
- 메시지 전송 시 아내 전화번호 없으면 안내 Alert
- 플레이스홀더: "말로는 부끄러운 마음, 글로 전해보세요"

## 홈 화면 (Home)
- 미션 설명에 메시지 기능 추가
- 버튼 텍스트: "미션 & 메시지 보내기"
- 챗봇 버튼에 툴팁 추가 ("궁금한 게 있다면 챗봇에게 물어보세요!")

## 📌 PR 내용

- 어떤 작업을 했나요?
- 주요 변경 사항 요약

---

## 🔗 관련 이슈

- Closes #이슈번호
- 또는 없음
